### PR TITLE
fix: stabilize submodule update workflow PR step

### DIFF
--- a/.github/workflows/update_submodules.yml
+++ b/.github/workflows/update_submodules.yml
@@ -77,6 +77,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          BRANCH="submodules-update-$TODAY"
+          BASE="${{ github.ref_name }}"
+
+          # Avoid failing reruns when a PR already exists for this branch.
+          if [ "$(gh pr list --head "$BRANCH" --base "$BASE" --state open --json number --jq 'length')" -gt 0 ]; then
+            echo "PR already exists for $BRANCH -> $BASE; skipping creation."
+            exit 0
+          fi
+
           gh pr create \
-            --fill \
-            --base ${{ github.ref_name }}
+            --title "Update submodules $TODAY" \
+            --body "Automated submodule update for $TODAY." \
+            --base "$BASE" \
+            --head "$BRANCH"


### PR DESCRIPTION
## Summary
- make `gh pr create` explicit by setting `--head`, `--title`, and `--body`
- add a guard that skips PR creation when one already exists for the update branch
- keep scheduled submodule updates rerun-safe to avoid false CI failures

## Test plan
- [x] Inspect workflow diff for valid shell/YAML
- [ ] Trigger `Update submodules` workflow manually in GitHub Actions
- [ ] Confirm workflow succeeds when no existing PR is present
- [ ] Re-run the workflow and confirm it exits cleanly when PR already exists

Made with [Cursor](https://cursor.com)